### PR TITLE
Update ChunkedUpload.java

### DIFF
--- a/chunkedupload/ChunkedUpload.java
+++ b/chunkedupload/ChunkedUpload.java
@@ -158,6 +158,8 @@ public class ChunkedUpload
                     fos = new FileOutputStream(outFile);
                     fos.write(buf, 0, numRead);
                     fos.close();
+                    //reset upload attempts on success chunk upload
+                    attemptUpload = 0;
                 } catch (IOException ex) {
                     log.info("err: ", ex);
                 }


### PR DESCRIPTION
Reset upload attempts every time a chunk is successfully uploaded, This case was added to handle large file uploads with poor network.